### PR TITLE
added start macro parameter and handling to skip bed mesh

### DIFF
--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -15,6 +15,7 @@ variable_fl_size: "0_0_0_0"
 variable_bed_mesh_profile: ""
 variable_total_layer: 0
 variable_adaptive_primeline: 1
+variable_skip_bedmesh: 0
 gcode:
     # Get all the parameters passed from the slicer
     {% set BED_TEMP = params.BED_TEMP|default(printer["gcode_macro _USER_VARIABLES"].print_default_bed_temp)|float %} # Bed temperature
@@ -31,6 +32,7 @@ gcode:
     {% set SYNC_MMU_EXTRUDER = params.SYNC_MMU_EXTRUDER|default(0)|int %} # set MMU gear motor and extruder synchronization during print TODO
     {% set BED_MESH_PROFILE = params.MESH|default("")|string %} # Bed mesh profile to load
     {% set ADAPTIVE_PRIMELINE = params.ADAPTIVE_PRIMELINE|default(1)|int %} # Weither to do or not an adaptive prime line near the real print zone
+    {% set SKIP_BEDMESH = params.SKIP_BEDMESH|default(0)|int %}
 
     # Set the variables to be used in all the modules based on the slicer parameters
     SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=bed_temp VALUE={BED_TEMP}
@@ -46,6 +48,7 @@ gcode:
     SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=fl_size VALUE='"{FL_SIZE}"'
     SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=bed_mesh_profile VALUE='"{BED_MESH_PROFILE}"'
     SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=adaptive_primeline VALUE={ADAPTIVE_PRIMELINE}
+    SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=skip_bedmesh VALUE={SKIP_BEDMESH}
     
     {% if params.TOTAL_LAYER %} # total layers count (if provided by the slicer)
         SET_PRINT_STATS_INFO TOTAL_LAYER={params.TOTAL_LAYER|int}
@@ -89,7 +92,7 @@ gcode:
 
     CLEAR_PAUSE
 
-    {% if bed_mesh_enabled %}
+    {% if bed_mesh_enabled and not skip_bedmesh == 1 %}
         BED_MESH_CLEAR
     {% endif %}
 
@@ -417,9 +420,10 @@ gcode:
 
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
+    {% set skip_bedmesh = printer["gcode_macro START_PRINT"].skip_bedmesh %}
     {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
 
-    {% if bed_mesh_enabled %}
+    {% if bed_mesh_enabled and not skip_bedmesh == 1 %}
         {% if BED_MESH_PROFILE == "" %}
             {% if verbose %}
                 RESPOND MSG="Bed mesh measurement..."


### PR DESCRIPTION
Useful if you want to print multi color first layer, add SKIP_BEDMESH=1 to macro in slicer